### PR TITLE
Rust codecov example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: rust
+rust:
+  - 1.9.0
+
+before_install:
+  - sudo apt-get update
+
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - cmake
+      - gcc
+      - binutils-dev
+
+after_success: |
+  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+  tar xzf master.tar.gz &&
+  cd kcov-master &&
+  mkdir build &&
+  cd build &&
+  cmake .. &&
+  make &&
+  sudo make install &&
+  cd ../.. &&
+  rm -rf kcov-master &&
+  for file in target/debug/examplerust-*; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+  bash <(curl -s https://codecov.io/bash) &&
+  echo "Uploaded code coverage"
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "examplerust"
+version = "1.0.0"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "examplerust"
+version = "1.0.0"
+authors = ["Sunjay Varma <varma.sunjay@gmail.com>"]
+
+[dependencies]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,122 @@
-# example-rust
+# Codecov Rust Example [![travisCI](https://travis-ci.org/codecov/example-rust.svg)](https://travis-ci.org/codecov/example-rust) [![codecov.io](http://codecov.io/github/codecov/example-rust/coverage.svg?branch=master)](http://codecov.io/github/codecov/example-rust?branch=master)
+
+| [https://codecov.io][1] | [@codecov][2] | [hello@codecov.io][3] |
+| ----------------------- | ------------- | --------------------- |
+
+This repository serves as an **example** of how to use [the Codecov global
+uploader][4] with Rust.
+
+Note that the coverage is deliberately incomplete. That
+way you can [follow the badge link][5] and see how [Codecov][1]
+works. You can view the code there, see hits and misses for coverage, etc.
+
+## Basic Usage
+
+Run your tests with [kcov][6] in order to create the necessary coverage
+reports. For example:
+
+```
+kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/<PROJECT-NAME>-<hash>
+```
+
+`<PROJECT-NAME>` and `<hash>` are the appropriate project name and hash for 
+your executable.
+
+Cargo typically generates two different executables: one for 
+unit tests and one for doctests. If you are building your code
+differently or without cargo, change the last two arguments
+to kcov to respectively represent where you want the coverage to
+be stored and which executable to run.
+
+Attempting to run `kcov` with an executable argument ending in a wildcard 
+like `<PROJECT-NAME>-*` may result in incorrect coverage results as only a 
+single test executable will run. **For best results, run the kcov command 
+for each test executable and store the results in separate directories.** 
+Codecov will automatically find and upload the cobertura.xml files and 
+merge the coverage for you.
+
+After you've run the tests and created a cobertura.xml report, you can use [the
+Codecov global uploader][4] to push that report to Codecov. See below for
+further details.
+
+## [![travis-org](https://avatars2.githubusercontent.com/u/639823?v=2&s=50)](https://travis-ci.org) Travis CI
+
+### Public Repos
+
+Adjust the following example `.travis.yml` file to test with the versions 
+of Rust you desire.
+
+```yml
+language: rust
+rust:
+  - 1.9.0
+
+before_install:
+  - sudo apt-get update
+
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - cmake
+      - gcc
+      - binutils-dev
+
+after_success: |
+  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+  tar xzf master.tar.gz &&
+  cd kcov-master &&
+  mkdir build &&
+  cd build &&
+  cmake .. &&
+  make &&
+  sudo make install &&
+  cd ../.. &&
+  rm -rf kcov-master &&
+  for file in target/debug/<PROJECT-NAME>-*; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+  bash <(curl -s https://codecov.io/bash) &&
+  echo "Uploaded code coverage"
+```
+
+[Codecov][1] is integrated by the following line in `after_success:`.
+
+```yml
+bash <(curl -s https://codecov.io/bash)
+```
+
+This will automatically run each executable and store the results in a
+different directory. Codecov will automatically find the `cobertura.xml`
+files that `kcov` generates and combine the results.
+
+### Private Repos
+
+Add to your `.travis.yml` file.
+
+```yml
+env:
+  global:
+    - CODECOV_TOKEN=:uuid-repo-token
+```
+
+## Other CI services
+
++ Adjust the materials in the above example as necessary for
+  your CI.
++ Add `CODECOV_TOKEN=<your repo token>` to your CI's environment variables.
+  (Don't store the raw token in your repo.)
++ Run `bash <(curl -s https://codecov.io/bash)` after tests complete.
+
+## More details
+
+Visit [the global uploader's repo][4] to view its source and
+learn more about the script.
+
+[1]: https://codecov.io
+[2]: https://twitter.com/codecov
+[3]: mailto:hello@codecov.io
+[4]: https://github.com/codecov/codecov-bash
+[5]: http://codecov.io/github/codecov/example-rust?branch=master
+[6]: https://simonkagstrom.github.io/kcov/
+

--- a/README.md
+++ b/README.md
@@ -19,31 +19,42 @@ reports. For example:
 kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/<PROJECT-NAME>-<hash>
 ```
 
-`<PROJECT-NAME>` and `<hash>` are the appropriate project name and hash for 
+`<PROJECT-NAME>` and `<hash>` are the appropriate project name and hash for
 your executable.
 
-Cargo typically generates two different executables: one for 
+Cargo typically generates two different executables: one for
 unit tests and one for doctests. If you are building your code
 differently or without cargo, change the last two arguments
 to kcov to respectively represent where you want the coverage to
 be stored and which executable to run.
 
-Attempting to run `kcov` with an executable argument ending in a wildcard 
-like `<PROJECT-NAME>-*` may result in incorrect coverage results as only a 
-single test executable will run. **For best results, run the kcov command 
-for each test executable and store the results in separate directories.** 
-Codecov will automatically find and upload the cobertura.xml files and 
+Attempting to run `kcov` with an executable argument ending in a wildcard
+like `<PROJECT-NAME>-*` may result in incorrect coverage results as only a
+single test executable will run. **For best results, run the kcov command
+for each test executable and store the results in separate directories.**
+Codecov will automatically find and upload the cobertura.xml files and
 merge the coverage for you.
 
-After you've run the tests and created a cobertura.xml report, you can use [the
-Codecov global uploader][4] to push that report to Codecov. See below for
-further details.
+After you've run the tests and created a cobertura.xml report, you can
+use [the Codecov global uploader][4] to push that report to Codecov.
+See below for further details.
+
+Installing `kcov` is largely dependent on your operating system. It is
+demonstrated to work on Linux systems but may not be fully compatible with
+Windows or OS X. Please lookup the appropriate installation instructions.
+The Travis CI example below demonstrates installing `kcov` on a Linux
+computer.
+
+The version of `kcov` that is distributed with your package manager may not
+work with Rust binaries. You usually need to manually build the latest
+master branch and run kcov from there. All of this is taken care of for you
+in the `.travis.yml` file below.
 
 ## [![travis-org](https://avatars2.githubusercontent.com/u/639823?v=2&s=50)](https://travis-ci.org) Travis CI
 
 ### Public Repos
 
-Adjust the following example `.travis.yml` file to test with the versions 
+Adjust the following example `.travis.yml` file to test with the versions
 of Rust you desire.
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ kcov --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/<PROJEC
 `<PROJECT-NAME>` and `<hash>` are the appropriate project name and hash for
 your executable.
 
-Cargo typically generates two different executables: one for
-unit tests and one for doctests. If you are building your code
+The hash at the end may change if cargo generates different test
+executables with the same name. If you are building your code
 differently or without cargo, change the last two arguments
 to kcov to respectively represent where you want the coverage to
 be stored and which executable to run.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,62 @@
+const EYES: &'static str = ":";
+
+pub fn smile() -> String {
+    format!("{}{}", EYES, ")")
+}
+
+pub fn frown() -> String {
+    format!("{}{}", EYES, "(")
+}
+
+pub fn angry() -> String {
+    format!("{}{}{}", ">", EYES, "(")
+}
+
+/// Provides a string representation of a face
+///
+/// # Examples
+///
+/// ```
+/// # use examplerust::*;
+/// assert_eq!(which(&frown()), "Frown");
+/// ```
+pub fn which(face: &str) -> &'static str {
+    if face == smile() {
+        "Smile"
+    }
+    else if face == frown() {
+        "Frown"
+    }
+    else if face == angry() {
+        "Angry"
+    }
+    else {
+        "I don't know"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_smile() {
+        assert_eq!(smile(), ":)");
+    }
+
+    #[test]
+    fn can_frown() {
+        assert_eq!(frown(), ":(");
+    }
+
+    #[test]
+    fn can_angry() {
+        assert_eq!(angry(), ">:(");
+    }
+
+    #[test]
+    fn string_representation() {
+        assert_eq!(which(&smile()), "Smile");
+    }
+}
+


### PR DESCRIPTION
@stevepeak 

[Rendered README.md](https://github.com/codecov/example-rust/blob/rust-codecov-example/README.md)

Much of this is based off of [codecov/example-lua](https://github.com/codecov/example-lua). The tests all pass and the coverage is left intentionally incomplete to better show off the output.

After you review this and any comments you have are integrated, there are a few remaining items that will require @stevepeak or someone else's admin privileges. 
## TODO
- [x] The Travis CI build needs to be enabled **(by someone with admin access)** and tested
- [x] Badges need to be checked to make sure that the travis and codecov integration is working
