### PR TITLE
Simplify travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,14 @@
 language: rust
 rust:
-  - 1.9.0
+  - stable
 
-before_install:
-  - sudo apt-get update
-
+sudo: false
 addons:
   apt:
     packages:
-      - libcurl4-openssl-dev
-      - libelf-dev
-      - libdw-dev
-      - cmake
-      - gcc
-      - binutils-dev
+      - kcov
 
 after_success: |
-  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
-  tar xzf master.tar.gz &&
-  cd kcov-master &&
-  mkdir build &&
-  cd build &&
-  cmake .. &&
-  make &&
-  sudo make install &&
-  cd ../.. &&
-  rm -rf kcov-master &&
   for file in target/debug/examplerust-*; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
   bash <(curl -s https://codecov.io/bash) &&
   echo "Uploaded code coverage"


### PR DESCRIPTION
- Use packaged kcov.
- Use faster container architecture (i.e. `sudo: false`).
- Use stable rust.