### PR TITLE
Prevent dead-code-elimination before coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ matrix:
   allow_failures:
     - rust: nightly
 
+env:
+  global:
+  - RUSTFLAGS="-C link-dead-code"
+
 before_install:
   - sudo apt-get update
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ merge the coverage for you.
 
 Note that setting the environment variable `RUSTFLAGS="-C link-dead-code"`
 during tests build may improve coverage accuracy by preventing dead-code elimination.
-This variable should not be set when building releases since it will increase
+Do not set this variable when creating release builds since it will increase
 binary size.
 
 After you've run the tests and created a cobertura.xml report, you can

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ for each test executable and store the results in separate directories.**
 Codecov will automatically find and upload the cobertura.xml files and
 merge the coverage for you.
 
+Note that setting the environment variable `RUSTFLAGS="-C link-dead-code"`
+during tests build may improve coverage accuracy by preventing dead-code elimination.
+This variable should not be set when building releases since it will increase
+binary size.
+
 After you've run the tests and created a cobertura.xml report, you can
 use [the Codecov global uploader][4] to push that report to Codecov.
 See below for further details.
@@ -70,6 +75,10 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+
+env:
+  global:
+  - RUSTFLAGS="-C link-dead-code"
 
 before_install:
   - sudo apt-get update

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,9 +35,11 @@ pub fn which(face: &str) -> &'static str {
     }
 }
 
-/// This function is not called in tests. It will be considered as dead code.
-/// Because of dead-code elimination it won't be reported as uncovered
-/// since the function will be removed from executable
+/// This function is not called during tests thus it will be considered as dead code.
+/// By default, and because of dead-code elimination it won't be reported as uncovered
+/// since the function will be removed from executable. Hopefully you can pass
+/// the rustflag `-C link-dead-code` when building the tests in order to
+/// prevent dead-code elimination
 pub fn not_called() {
     println!("This is dead code");
     unreachable!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,14 @@ pub fn which(face: &str) -> &'static str {
     }
 }
 
+/// This function is not called in tests. It will be considered as dead code.
+/// Because of dead-code elimination it won't be reported as uncovered
+/// since the function will be removed from executable
+pub fn not_called() {
+    println!("This is dead code");
+    unreachable!();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,12 @@ pub fn which(face: &str) -> &'static str {
     }
 }
 
-/// This function is not called during tests thus it will be considered as dead code.
+/// This function is not called during tests, so it will be considered dead code.
 /// By default, and because of dead-code elimination it won't be reported as uncovered
-/// since the function will be removed from executable. Hopefully you can pass
-/// the rustflag `-C link-dead-code` when building the tests in order to
-/// prevent dead-code elimination
+/// since the function will be removed from executable.
+/// This is accounted for in the Travis configuration by passing the compiler flag
+/// `-C link-dead-code` when building the tests. This flag disables dead code
+/// elimination and allows this function to be reported correctly.
 pub fn not_called() {
     println!("This is dead code");
     unreachable!();


### PR DESCRIPTION
By default, there's a **dead-code elimination** optimization made on rust binary during build process, even for a non --release build.
This dead-code elimination may lead to inaccurate code coverage reports. For example, a function which is not called at all during tests, will be removed from binary, and won't be reported as uncovered. See [my example](https://codecov.io/gh/phsym/example-rust/src/c1961f11f2cb7aa2d259cc02684d068108192a5b/src/lib.rs#L41) in which I added a untested function, which is not reported as uncovered.

As per rust-lang/rust#31368, passing `-C link-dead-code` to `rustc` compiler deactivate dead-code-elimination, improving code coverage accuracy.
When building with `cargo`, this flag is passed through the environment variable `RUSTFLAGS`.

Thus, I added `RUSTFLAGS="-C link-dead-code"` to travis build environment variable and updated README with a note about it.
Now the function is reported as uncovered (see [example](https://codecov.io/gh/phsym/example-rust/src/7658dfdf52ca78311dc09ee3dcabf7e9413833a4/src/lib.rs#L43) where the untested function is now reported as uncovered)