### PR TITLE
Adds apt-get dependency to libiberty-dev, so that kcov can find libbfd

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ addons:
       - cmake
       - gcc
       - binutils-dev
+      - libiberty-dev
 
 after_success: |
   wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&


### PR DESCRIPTION
Without this line, kcov segfaults on me while trying to run my tests, complaining about a missing LIBBFD_IBERTY library. 