### PR TITLE
Fix Bash glob when Rust hash ends in d

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,6 @@ after_success: |
   make install DESTDIR=../../kcov-build &&
   cd ../.. &&
   rm -rf kcov-master &&
-  for file in target/debug/examplerust-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+  for file in target/debug/examplerust-*; [ -x "${file}" ] || continue; do mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
   bash <(curl -s https://codecov.io/bash) &&
   echo "Uploaded code coverage"


### PR DESCRIPTION
When the Rust hash ends in a "d" the previous blob would fail to match.
This is due to #3 which fixed an issue where Rust generated ".d" files
that should correctly be filtered.

This new version loops over both the correct files and ".d" files.
Within the loop it checks for if the file is executable as its
filtering of the ".d" files.

I believe in general this is a better design as the more advanced Bash
glob is not very portable.