### PR TITLE
Improve clarity of command to be changed by user in .travis.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 ### Travis Setup
 
 Add to your `.travis.yml` file.
+
+**NOTE: You should change `examplerust` in `for file in target/debug/examplerust-* ...` (under `after_success`) to match your package name.** For example, if your package name is `minigrep`, then the lines should be changed to `for file in target/debug/minigrep-* ...`. If you are not sure what your package name, it can also be found in `Cargo.toml` and it is usually the same name as when you had initialised the project.
 ```yml
 language: rust
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Add to your `.travis.yml` file.
 
-**NOTE: You should change `examplerust` in `for file in target/debug/examplerust-* ...` (under `after_success`) to match your package name.** For example, if your package name is `minigrep`, then the lines should be changed to `for file in target/debug/minigrep-* ...`. If you are not sure what your package name, it can also be found in `Cargo.toml` and it is usually the same name as when you had initialised the project.
+**NOTE: You should change `examplerust` in `for file in target/debug/examplerust-* ...` (under `after_success`) to match your package name.** For example, if your package name is `minigrep`, then the lines should be changed to `for file in target/debug/minigrep-* ...`. If you are not sure what your package name is, it can also be found in `Cargo.toml` and it is usually the same name as when you had initialised the project.
 ```yml
 language: rust
 


### PR DESCRIPTION
I am fairly new to Rust, and when setting up coverage, I had blindly followed this README and copy-pasted the `.travis.yml` configuration as-is. I could not produce the coverage report as desired, and after a few hours of reading up various resources did I realise that I should modify `examplerust` to something else.

I would like to add this note in the README, so that future users who might be setting up code coverage can be clearer in what additional changes they might need to make. 