### PR TITLE
Readme prompts to create an issue, but this is not possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fcodecov%2Fexample-rust.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fcodecov%2Fexample-rust?ref=badge_shield)
 
 
-**As of July 2, 2016, there is [no option to make rustdoc generate a runnable test executable][7]. That means that documentation tests will not show in your coverage data. If you discover a way to run the doctest executable with kcov, please ??? and we will add that to these instructions.**
+**As of July 2, 2016, there is [no option to make rustdoc generate a runnable test executable][7]. That means that documentation tests will not show in your coverage data. If you discover a way to run the doctest executable with kcov, please open an issue in our [feedback repository](https://github.com/codecov/feedback) and we will add that to these instructions.**
 
 ## Guide
 ### Travis Setup

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fcodecov%2Fexample-rust.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fcodecov%2Fexample-rust?ref=badge_shield)
 
 
-**As of July 2, 2016, there is [no option to make rustdoc generate a runnable test executable][7]. That means that documentation tests will not show in your coverage data. If you discover a way to run the doctest executable with kcov, please open an [Issue][8] and we will add that to these instructions.**
+**As of July 2, 2016, there is [no option to make rustdoc generate a runnable test executable][7]. That means that documentation tests will not show in your coverage data. If you discover a way to run the doctest executable with kcov, please ??? and we will add that to these instructions.**
 
 ## Guide
 ### Travis Setup

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ We are happy to help if you have any questions. Please contact email our Support
 [5]: http://codecov.io/github/codecov/example-rust?branch=master
 [6]: https://simonkagstrom.github.io/kcov/
 [7]: http://stackoverflow.com/questions/35547710/does-rustdoc-generate-runnable-binaries
-[8]: https://github.com/codecov/example-rust/issues
 
 
 ## License


### PR DESCRIPTION
[`librustdoc`](https://github.com/rust-lang/rust/tree/master/src/librustdoc) now has `persist_doctests` bool, so I wanted to create an issue.

But that's not the point! The instructions in this repo are not consistent with its settings at Github. Please fix it one way or another. I suggest changing the settings of this repo to allow issues.